### PR TITLE
Fix UnboundLocalError in __init__.py

### DIFF
--- a/circup/__init__.py
+++ b/circup/__init__.py
@@ -525,6 +525,7 @@ def extract_metadata(path):
         mpy_version = content[0:2]
         compatibility = None
         # Find the start location of the __version__
+        loc = 0
         if mpy_version == b"M\x03":
             # One byte for the length of "__version__"
             loc = content.find(b"__version__") - 1


### PR DESCRIPTION
loc at __init_.py:537 can be uninitialized

<!-- SPDX-FileCopyrightText: 2019 Nicholas Tollervey, written for Adafruit Industries

SPDX-License-Identifier: MIT -->
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  
variable loc at __init__.py:537 can be uninitialized, leading to the following error:
```
SiMini:mef90-dmplex (dmplex)$ circup install neopixel
Found device at /Volumes/CIRCUITPY, running CircuitPython 7.3.0.
Searching for dependencies for: ['neopixel']
Traceback (most recent call last):
  File "/opt/homebrew/bin/circup", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/homebrew/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/homebrew/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/homebrew/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/homebrew/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/opt/homebrew/lib/python3.9/site-packages/circup/__init__.py", line 1311, in install
    device_modules = get_device_versions(ctx.obj["DEVICE_PATH"])
  File "/opt/homebrew/lib/python3.9/site-packages/circup/__init__.py", line 903, in get_device_versions
    return get_modules(os.path.join(device_path, "lib"))
  File "/opt/homebrew/lib/python3.9/site-packages/circup/__init__.py", line 944, in get_modules
    metadata = extract_metadata(sfm)
  File "/opt/homebrew/lib/python3.9/site-packages/circup/__init__.py", line 536, in extract_metadata
   if loc > -1:
   UnboundLocalError: local variable 'loc' referenced before assignment
```

- **Describe any known limitations with your change.**  
 None that I know of

- **Please run any tests or examples that can exercise your modified code.**  `circup install neopixel` now works
